### PR TITLE
feat: add home page and profile page

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -25,5 +25,5 @@
     "128": "src/assets/os-icons/os-icon-128.png"
   },
   "host_permissions": ["<all_urls>"],
-  "permissions": ["storage","webRequest"]
+  "permissions": ["storage","webRequest", "activeTab"]
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,6 @@ type RouteKeys = keyof typeof routes;
 
 function App() {
   const {isTokenValid} = useAuth()
-  // renderedPage can be either "start", "home" or "loading"
   const [renderedPage, setRenderedPage] = useState<{name: RouteKeys, props?: any}>({name: "loading", props: {}});
 
   const setCurrentPage = (name: RouteKeys, props: any = {}) => {
@@ -28,7 +27,6 @@ function App() {
 
 
   useEffect(() => {
-    // console.log("isTokenValid", isTokenValid)
     if(isTokenValid === null) {
       setCurrentPage("loading")
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,44 +1,52 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, createContext } from "react";
 
 import Start from "./pages/start";
 import Home from "./pages/home";
 import Loading from "./pages/loading";
+import { Profile } from "./pages/profile";
+import { useAuth } from "./hooks/useAuth";
 
-import { checkTokenValidity } from "./utils/fetchOpenSaucedApiData";
+export const RouteContext = createContext<{page: {name: string, props?: any}, setCurrentPage: (page: RouteKeys, props?: any) => void}>({page: {name: "loading"}, setCurrentPage: () => {}});
+
+const routes = {
+  start: <Start />,
+  home: <Home />,
+  loading: <Loading />,
+  profile: <Profile />
+}
+
+type RouteKeys = keyof typeof routes;
 
 function App() {
-  const [osAccessToken, setOsAccessToken] = useState("");
+  const {isTokenValid} = useAuth()
   // renderedPage can be either "start", "home" or "loading"
-  const [renderedPage, setRenderedPage] = useState("loading");
+  const [renderedPage, setRenderedPage] = useState<{name: RouteKeys, props?: any}>({name: "loading", props: {}});
+
+  const setCurrentPage = (name: RouteKeys, props: any = {}) => {
+    setRenderedPage({name: name, props})
+  }
+
 
   useEffect(() => {
-    chrome.storage.sync.get(["os-access-token"], (result) => {
-      if (result["os-access-token"]) {
-        checkTokenValidity(result["os-access-token"]).then((valid) => {
-          if (!valid) {
-            setOsAccessToken("");
-            setRenderedPage("signin");
-          } else {
-            setOsAccessToken(result["os-access-token"]);
-            setRenderedPage("home");
-          }
-        });
-      } else {
-        setRenderedPage("start");
-      }
-    });
-  }, []);
+    // console.log("isTokenValid", isTokenValid)
+    if(isTokenValid === null) {
+      setCurrentPage("loading")
+    }
+    else if(isTokenValid) {
+      setCurrentPage("home")
+    } 
+    else {
+      setCurrentPage("start")
+    }
+  }, [isTokenValid]);
 
   return (
-    <div className="p-4 bg-slate-800">
-      {renderedPage === "start" ? (
-        <Start setRenderedPage={setRenderedPage} />
-      ) : renderedPage === "home" ? (
-        <Home osAccessToken={osAccessToken} setRenderedPage={setRenderedPage} />
-      ) : (
-        <Loading />
-      )}
-    </div>
+    <RouteContext.Provider value={{page: renderedPage, setCurrentPage: setCurrentPage}}>
+      <div className="p-4 bg-slate-800">
+        {routes[renderedPage.name]}
+        </div>
+    </RouteContext.Provider>
+    
   );
 }
 

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,0 +1,54 @@
+import { useEffect, useState } from "react"
+import { cachedFetch } from "../utils/cache"
+
+const removeTokenFromStorage = () => {
+  return new Promise((resolve, reject) => {
+
+    chrome.storage.sync.remove("os-access-token", () => {
+      console.log("token removed")
+      resolve(true)
+    })
+  })
+}
+
+export const useAuth = () => {
+  const [authToken, setAuthToken] = useState<null | string>(null)
+  const [user, setUser] = useState<null | { id: string, user_name: string }>(null)
+  const [isTokenValid, setIsTokenValid] = useState<boolean|null>(null)
+  
+  useEffect(() => {
+    chrome.storage.sync.get(["os-access-token"], (result) => {
+      if (result["os-access-token"]) {
+        setAuthToken(result['os-access-token'])
+        //get account data
+        cachedFetch('https://api.opensauced.pizza/v1/auth/session', {
+          expireInSeconds: 2 * 60 * 60, // 2 hours
+          headers: {
+            Authorization: `Bearer ${result['os-access-token']}`,
+            Accept: 'application/json',
+          },
+        }).then((resp) => {
+          if (!resp.ok) {
+            console.log('error getting user info')
+            removeTokenFromStorage().then(() => {
+              setAuthToken(null)
+              setUser(null)
+              setIsTokenValid(false)
+            })
+          }
+          return resp.json()
+        })
+          .then((json) => {
+            // console.log(json)
+            setUser(json)
+            setIsTokenValid(true)
+          })
+      } else {
+        console.log('No auth token found')
+        setIsTokenValid(false)
+      }
+    });
+  }, [])
+
+  return { authToken, user, isTokenValid }
+}

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -6,7 +6,6 @@ const removeTokenFromStorage = () => {
   return new Promise((resolve, reject) => {
 
     chrome.storage.sync.remove(OPEN_SAUCED_AUTH_TOKEN_KEY, () => {
-      console.log("token removed")
       resolve(true)
     })
   })
@@ -40,12 +39,10 @@ export const useAuth = () => {
           return resp.json()
         })
           .then((json) => {
-            // console.log(json)
             setUser(json)
             setIsTokenValid(true)
           })
       } else {
-        console.log('No auth token found')
         setIsTokenValid(false)
       }
     });

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react"
-import { OPEN_SAUCED_AUTH_TOKEN_KEY } from "../constants"
+import { OPEN_SAUCED_AUTH_TOKEN_KEY, OPEN_SAUCED_SESSION_ENDPOINT } from "../constants"
 import { cachedFetch } from "../utils/cache"
 
 const removeTokenFromStorage = () => {
@@ -20,9 +20,9 @@ export const useAuth = () => {
   useEffect(() => {
     chrome.storage.sync.get([OPEN_SAUCED_AUTH_TOKEN_KEY], (result) => {
       if (result[OPEN_SAUCED_AUTH_TOKEN_KEY]) {
-        setAuthToken(result['os-access-token'])
+        setAuthToken(result[OPEN_SAUCED_AUTH_TOKEN_KEY])
         //get account data
-        cachedFetch('https://api.opensauced.pizza/v1/auth/session', {
+        cachedFetch(OPEN_SAUCED_SESSION_ENDPOINT, {
           expireInSeconds: 2 * 60 * 60, // 2 hours
           headers: {
             Authorization: `Bearer ${result['os-access-token']}`,

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -25,7 +25,7 @@ export const useAuth = () => {
         cachedFetch(OPEN_SAUCED_SESSION_ENDPOINT, {
           expireInSeconds: 2 * 60 * 60, // 2 hours
           headers: {
-            Authorization: `Bearer ${result['os-access-token']}`,
+            Authorization: `Bearer ${result[OPEN_SAUCED_AUTH_TOKEN_KEY]}`,
             Accept: 'application/json',
           },
         }).then((resp) => {

--- a/src/hooks/useOpensaucedUserCheck.ts
+++ b/src/hooks/useOpensaucedUserCheck.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from "react"
+import { isOpenSaucedUser } from "../utils/fetchOpenSaucedApiData"
+import { getGithubUsername } from "../utils/urlMatchers"
+
+export const useOpensaucedUserCheck = () => {
+  const [currentTabIsOpensaucedUser, setCurrentTabIsOpensaucedUser] = useState(false)
+  const [checkedUser, setCheckedUser] = useState<string|null>(null)
+  useEffect(() => {
+    //get active tab
+    chrome.tabs.query({ active: true, currentWindow: true }, async (tabs) => {
+      if (tabs.length > 0) {
+        const tab = tabs[0]
+        const username = getGithubUsername(tab.url!)
+        if(username != null) {
+          setCheckedUser(username)
+          setCurrentTabIsOpensaucedUser(await isOpenSaucedUser(username))
+        } else {
+          setCheckedUser(null)
+          setCurrentTabIsOpensaucedUser(false)
+        }       
+      }
+    })
+  }, [])
+  
+
+  return { currentTabIsOpensaucedUser, checkedUser }
+}

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -40,11 +40,11 @@ function Home() {
           </a>
           <a
             target='_blank'
-            href={`https://insights.opensauced.pizza/user/${user?.user_name}`}
+            href={`https://insights.opensauced.pizza`}
             className='flex items-center bg-slate-700 hover:bg-slate-700/70 hover:text-orange text-white gap-2 p-1.5 px-3 w-full rounded-sm font-medium text-sm'
           >
             <HiArrowTopRightOnSquare />
-            Go to Dashboard page
+            Go to Dashboard
           </a>
           {
             currentTabIsOpensaucedUser &&

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -36,7 +36,7 @@ function Home() {
             className='flex items-center bg-slate-700 hover:bg-slate-700/70 text-white hover:text-orange no-underline gap-2 p-1.5 px-3 w-full rounded-sm font-medium text-sm'
           >
             <HiArrowTopRightOnSquare />
-            Go to Highlight page
+            Go to Highlights feed
           </a>
           <a
             target='_blank'
@@ -54,7 +54,7 @@ function Home() {
               }} 
               className="flex items-center bg-slate-700 hover:bg-slate-700/70 hover:text-orange text-white gap-2 p-1.5 px-3 w-full rounded-sm font-medium text-sm">
                 <HiUserCircle />
-                See {checkedUser} profile
+                View {checkedUser}'s profile
             </button>
           }
         </div>

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -1,14 +1,64 @@
-import React from "react";
+import React, { useContext } from "react";
+import { HiArrowTopRightOnSquare, HiUserCircle } from 'react-icons/hi2'
+import { RouteContext } from "../App";
+import OpenSaucedLogo from "../assets/opensauced-logo.svg";
+import { useAuth } from "../hooks/useAuth";
+import { useOpensaucedUserCheck } from "../hooks/useOpensaucedUserCheck";
 
-interface HomeProps {
-  osAccessToken: string;
-  setRenderedPage: (page: string) => void;
-}
+function Home() {
+  const {setCurrentPage} = useContext(RouteContext)
+  const {user} = useAuth()
+  const {currentTabIsOpensaucedUser, checkedUser} = useOpensaucedUserCheck()
 
-function Home({ osAccessToken, setRenderedPage }: HomeProps) {
   return (
-    <div>
-      <p className="text-white">Home</p>
+    <div className="grid grid-cols-1 divide-y divide-white/40 divider-y-center-2 min-w-[320px] text-white">
+      <header className='flex justify-between'>
+        <img src={OpenSaucedLogo} alt="OpenSauced logo" className='w-[45%]' />
+        {user &&
+          <button 
+            onClick={e=> {
+              setCurrentPage('profile', {userName: user.user_name})
+            }}
+            className='flex gap-1 items-center hover:text-orange text-white no-underline'>
+            {user?.user_name}
+            <img
+              src={`https://github.com/${user?.user_name}.png`}
+              alt="profile image"
+              className='rounded-full w-6 aspect-square border border-orange' />
+          </button>}
+      </header>
+      <main className='main-content'>
+        <h3 className='text font-medium text-base leading-10'>Tools:</h3>
+        <div className='tools flex flex-col gap-2'>
+          <a
+            target='_blank'
+            href={`https://insights.opensauced.pizza/feed`}
+            className='flex items-center bg-slate-700 hover:bg-slate-700/70 text-white hover:text-orange no-underline gap-2 p-1.5 px-3 w-full rounded-sm font-medium text-sm'
+          >
+            <HiArrowTopRightOnSquare />
+            Go to Highlight page
+          </a>
+          <a
+            target='_blank'
+            href={`https://insights.opensauced.pizza/user/${user?.user_name}`}
+            className='flex items-center bg-slate-700 hover:bg-slate-700/70 hover:text-orange text-white gap-2 p-1.5 px-3 w-full rounded-sm font-medium text-sm'
+          >
+            <HiArrowTopRightOnSquare />
+            Go to Dashboard page
+          </a>
+          {
+            currentTabIsOpensaucedUser &&
+            <button
+              onClick={e => {
+                setCurrentPage('profile', {userName: checkedUser})
+              }} 
+              className="flex items-center bg-slate-700 hover:bg-slate-700/70 hover:text-orange text-white gap-2 p-1.5 px-3 w-full rounded-sm font-medium text-sm">
+                <HiUserCircle />
+                See {checkedUser} profile
+            </button>
+          }
+        </div>
+      </main>
     </div>
   );
 }

--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -88,7 +88,7 @@ export const Profile = () => {
           }
           {user?.bio && <p>This is my bio</p>}
           {user?.url &&
-            <a target={'_blank'} href={user.url} className='flex text-orange items-center gap-0.5'>
+            <a target={'_blank'} href={user.blog_url} className='flex text-orange items-center gap-0.5'>
               <RiLinkM />
               {user.url}
             </a>

--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -29,7 +29,7 @@ type InterestIconKeys = keyof typeof interestIcon;
 
 export const Profile = () => {
   const { page, setCurrentPage } = useContext(RouteContext)
-  const [user, setUser] = useState<null | { id: string, user_name: string, bio: string, created_at: string, linkedin_url: string, twitter_username: string, url: string, interests: string, open_issues: number }>(null)
+  const [user, setUser] = useState<null | { id: string, user_name: string, bio: string, created_at: string, linkedin_url: string, twitter_username: string, blog: string, interests: string, open_issues: number }>(null)
   const [userPR, setUserPR] = useState<null | { meta: {itemCount: number} }>(null)
 
 useEffect(() => {
@@ -92,10 +92,10 @@ useEffect(() => {
             </div>
           }
           {user?.bio && <span>{user.bio}</span>}
-          {user?.url &&
-            <a target={'_blank'} href={user.blog_url} className='flex text-orange items-center gap-0.5'>
+          {user?.blog &&
+            <a target={'_blank'} href={user.blog} className='flex text-orange items-center gap-0.5'>
               <RiLinkM />
-              {user.url}
+              {user.blog}
             </a>
           }
         </div>

--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -68,6 +68,7 @@ export const Profile = () => {
             <div className='social flex gap-0.5'>
               {user?.linkedin_url &&
                 <a 
+                  target={'_blank'}
                   href={user.linkedin_url} 
                   title={user.linkedin_url} 
                   className='rounded-sm border bg-slate-700 hover:bg-slate-700/50 hover:text-orange p-1'>
@@ -76,6 +77,7 @@ export const Profile = () => {
               }
               {user?.twitter_username &&
                 <a 
+                  target={'_blank'}
                   href={`https://twitter.com/${user.twitter_username}`} 
                   title={`https://twitter.com/${user.twitter_username}`} 
                   className='rounded-sm border bg-slate-700 hover:bg-slate-700/50 hover:text-orange p-1'>
@@ -86,7 +88,7 @@ export const Profile = () => {
           }
           {user?.bio && <p>This is my bio</p>}
           {user?.url &&
-            <a href="#" className='flex text-orange items-center gap-0.5'>
+            <a target={'_blank'} href={user.url} className='flex text-orange items-center gap-0.5'>
               <RiLinkM />
               {user.url}
             </a>

--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -32,10 +32,14 @@ export const Profile = () => {
   const [user, setUser] = useState<null | { id: string, user_name: string, bio: string, created_at: string, linkedin_url: string, twitter_username: string, url: string, interests: string, open_issues: number }>(null)
   const [userPR, setUserPR] = useState<null | { meta: {itemCount: number} }>(null)
 
-  useEffect(() => {
-    getUserData(page.props.userName).then((data) => { setUser(data)})
-    getUserPRData(page.props.userName).then((data) => { setUserPR(data)})
-  }, [])
+useEffect(() => {
+    const fetchUserData = async () => {
+        const [userData, userPRData] = await Promise.all([getUserData(page.props.userName), getUserPRData(page.props.userName)]);
+        setUser(userData);
+        setUserPR(userPRData);
+    }
+    fetchUserData();
+}, [])
 
 
   return (
@@ -50,9 +54,10 @@ export const Profile = () => {
         <button 
           title='Refresh user data'
           className='hover:text-orange text-lg' 
-          onClick={() => {
-            getUserData(page.props.userName, true).then((data) => { setUser(data)})
-            getUserPRData(page.props.userName, true).then((data) => { setUserPR(data)})
+          onClick={async () => {
+            const [userData, userPRData] = await Promise.all([getUserData(page.props.userName), getUserPRData(page.props.userName)]);
+            setUser(userData);
+            setUserPR(userPRData);
           }}>
           <AiOutlineReload />
         </button>

--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -1,0 +1,16 @@
+import { useContext, useEffect, useState } from 'react';
+import { FaBrain, FaChevronLeft, FaRobot } from 'react-icons/fa';
+import { RiLinkedinFill, RiLinkM, RiTwitterFill } from 'react-icons/ri';
+import { AiOutlineReload } from 'react-icons/ai';
+import OpenSaucedLogo from "../assets/opensauced-logo.svg";
+import { getUserData, getUserPRData } from '../utils/fetchOpenSaucedApiData';
+import { RouteContext } from '../App';
+
+export const Profile = () => {
+  const { page, setCurrentPage } = useContext(RouteContext)
+  return (
+    <div className="text-white">
+      <p>{page.props.userName}</p>
+    </div>
+  )
+}

--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -86,7 +86,7 @@ export const Profile = () => {
               }
             </div>
           }
-          {user?.bio && <p>This is my bio</p>}
+          {user?.bio && <span>{user.bio}</span>}
           {user?.url &&
             <a target={'_blank'} href={user.blog_url} className='flex text-orange items-center gap-0.5'>
               <RiLinkM />

--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -2,15 +2,132 @@ import { useContext, useEffect, useState } from 'react';
 import { FaBrain, FaChevronLeft, FaRobot } from 'react-icons/fa';
 import { RiLinkedinFill, RiLinkM, RiTwitterFill } from 'react-icons/ri';
 import { AiOutlineReload } from 'react-icons/ai';
+import { SiC, SiCplusplus, SiCsharp, SiGoland, SiJavascript, SiPhp, SiPython, SiReact, SiRuby, SiRust, SiTypescript } from 'react-icons/si';
+import { DiJava } from 'react-icons/di'
 import OpenSaucedLogo from "../assets/opensauced-logo.svg";
 import { getUserData, getUserPRData } from '../utils/fetchOpenSaucedApiData';
 import { RouteContext } from '../App';
 
+const interestIcon = {
+  'python': <SiPython />,
+  'java': <DiJava />,
+  'javascript': <SiJavascript />,
+  'typescript': <SiTypescript />,
+  'csharp': <SiCsharp />,
+  'cpp': <SiCplusplus />,
+  'c': <SiC />,
+  'php': <SiPhp />,
+  'ruby': <SiRuby />,
+  'react': <SiReact />,
+  'ml': <FaBrain />,
+  'ai': <FaRobot />,
+  'golang': <SiGoland />,
+  'rust': <SiRust />
+}
+
+type InterestIconKeys = keyof typeof interestIcon;
+
 export const Profile = () => {
   const { page, setCurrentPage } = useContext(RouteContext)
+  const [user, setUser] = useState<null | { id: string, user_name: string, bio: string, created_at: string, linkedin_url: string, twitter_username: string, url: string, interests: string, open_issues: number }>(null)
+  const [userPR, setUserPR] = useState<null | { meta: {itemCount: number} }>(null)
+
+  useEffect(() => {
+    getUserData(page.props.userName).then((data) => { setUser(data)})
+    getUserPRData(page.props.userName).then((data) => { setUserPR(data)})
+  }, [])
+
+
   return (
-    <div className="text-white">
-      <p>{page.props.userName}</p>
+    <div className="grid grid-cols-1 divide-y divider-y-center-2 min-w-[320px] text-white">
+      <header className='flex justify-between'>
+        <div className="flex items-center gap-2">
+          <button onClick={() => { setCurrentPage("home") }} className='rounded-full p-2 bg-slate-700 hover:bg-slate-700/50'>
+            <FaChevronLeft className='text-osOrange' />
+          </button>
+          <img src={OpenSaucedLogo} alt="OpenSauced logo" className='w-[100%]' />
+        </div>
+        <button 
+          title='Refresh user data'
+          className='hover:text-orange text-lg' 
+          onClick={() => {
+            getUserData(page.props.userName, true).then((data) => { setUser(data)})
+            getUserPRData(page.props.userName, true).then((data) => { setUserPR(data)})
+          }}>
+          <AiOutlineReload />
+        </button>
+      </header>
+      <main>
+        <div className='flex flex-col items-center gap-1 mb-4'>
+          <img
+            src={`https://github.com/${page.props.userName}.png`}
+            alt="profile image"
+            className='rounded-full w-14 aspect-square p-1 bg-slate-700' />
+          <p className='font-medium'>@{page.props.userName}</p>
+          {(user?.linkedin_url || user?.twitter_username) &&
+            <div className='social flex gap-0.5'>
+              {user?.linkedin_url &&
+                <a 
+                  href={user.linkedin_url} 
+                  title={user.linkedin_url} 
+                  className='rounded-sm border bg-slate-700 hover:bg-slate-700/50 hover:text-orange p-1'>
+                  <RiLinkedinFill className='text-lg' />
+                </a>
+              }
+              {user?.twitter_username &&
+                <a 
+                  href={`https://twitter.com/${user.twitter_username}`} 
+                  title={`https://twitter.com/${user.twitter_username}`} 
+                  className='rounded-sm border bg-slate-700 hover:bg-slate-700/50 hover:text-orange p-1'>
+                  <RiTwitterFill className='text-lg' />
+                </a>
+              }
+            </div>
+          }
+          {user?.bio && <p>This is my bio</p>}
+          {user?.url &&
+            <a href="#" className='flex text-orange items-center gap-0.5'>
+              <RiLinkM />
+              {user.url}
+            </a>
+          }
+        </div>
+        <div className='grid grid-cols-2 text-white bg-osOrange -mx-4 mb-4 p-4 py-8'>
+          <div className='flex flex-col items-center justify-center p-2 text-xs'>
+            <p>Open Issues</p>
+            <p className='font-medium text-5xl'>{user?.open_issues}</p>
+          </div>
+          <div className='flex flex-col items-center justify-center p-2 text-xs'>
+            <p>PRs Made</p>
+            <p className='font-medium text-5xl'>{userPR?.meta.itemCount}</p>
+          </div>
+          <div className='flex flex-col items-center justify-center p-2 text-xs'>
+            <p>Avg PRs Velocity</p>
+            <p className='font-medium text-5xl'>-</p>
+          </div>
+          <div className='flex flex-col items-center justify-center p-2 text-xs'>
+            <p>Contributed Repos</p>
+            <p className='font-medium text-5xl'>-</p>
+          </div>
+        </div>
+        {
+          <div>
+            <h2 className='font-medium text-lg mb-2'>Current Interest</h2>
+            <div className='flex gap-1.5' style={{flexWrap: 'wrap'}}>
+              {user?.interests.split(',').map((interest) => (
+                <a target="_blank" key={interest}
+                  href={`https://insights.opensauced.pizza/${interest}/dashboard/filter/recent`} 
+                  title={`https://insights.opensauced.pizza/${interest}/dashboard/filter/recent`} 
+                  className='flex gap-1 items-center p-1.5 px-4 rounded-full bg-slate-700 hover:bg-slate-700/50'>
+                  {interestIcon[interest as InterestIconKeys] ?? null}
+                  {interest}
+                </a>
+              )
+              )}
+            </div>
+          </div>
+        }
+      </main>
     </div>
   )
 }

--- a/src/pages/start.tsx
+++ b/src/pages/start.tsx
@@ -1,10 +1,7 @@
 import OpenSaucedLogo from "../assets/opensauced-logo.svg";
 
-interface StartProps {
-  setRenderedPage: (page: string) => void;
-}
+function Start() {
 
-function Start({ setRenderedPage }: StartProps) {
   return (
     <div>
       <img src={OpenSaucedLogo} alt="Open Sauced Logo" />

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -1,0 +1,50 @@
+export const cachedFetch = (url: string, options: number | RequestInit & {expireInSeconds: number, forceRefresh?: boolean} | undefined) => {
+  let expiry = 5 * 60 // 5 min default
+  if (typeof options === 'number') {
+    expiry = options
+    options = undefined
+  } else if (typeof options === 'object') {
+    // I hope you didn't set it to 0 seconds
+    expiry = options.expireInSeconds || expiry
+  }
+  // Use the URL as the cache key to sessionStorage
+  let cacheKey = url
+  let cached = localStorage.getItem(cacheKey)
+  let whenCached = localStorage.getItem(cacheKey + ':ts')
+  if (cached !== null && whenCached !== null && !options?.forceRefresh) {
+    // it was in sessionStorage! Yay!
+    // Even though 'whenCached' is a string, this operation
+    // works because the minus sign converts the
+    // string to an integer and it will work.
+    let age = (Date.now() - parseInt(whenCached)) / 1000
+    if (age < expiry) {
+      let response = new Response(new Blob([cached]))
+      return Promise.resolve(response)
+    } else {
+      // We need to clean up this old key
+      localStorage.removeItem(cacheKey)
+      localStorage.removeItem(cacheKey + ':ts')
+    }
+  }
+
+  return fetch(url, options).then(response => {
+    // let's only store in cache if the content-type is
+    // JSON or something non-binary
+    if (response.status === 200) {
+      let ct = response.headers.get('Content-Type')
+      if (ct && (ct.match(/application\/json/i) || ct.match(/text\//i))) {
+        // There is a .json() instead of .text() but
+        // we're going to store it in sessionStorage as
+        // string anyway.
+        // If we don't clone the response, it will be
+        // consumed by the time it's returned. This
+        // way we're being un-intrusive.
+        response.clone().text().then(content => {
+          localStorage.setItem(cacheKey, content)
+          localStorage.setItem(cacheKey+':ts', `${Date.now()}`)
+        })
+      }
+    }
+    return response
+  })
+}

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -1,50 +1,46 @@
-export const cachedFetch = (url: string, options: number | RequestInit & {expireInSeconds: number, forceRefresh?: boolean} | undefined) => {
-  let expiry = 5 * 60 // 5 min default
-  if (typeof options === 'number') {
-    expiry = options
-    options = undefined
-  } else if (typeof options === 'object') {
-    // I hope you didn't set it to 0 seconds
-    expiry = options.expireInSeconds || expiry
+export const cachedFetch = async (
+  url: string,
+  options:
+    | number
+    | (RequestInit & { expireInSeconds: number; forceRefresh?: boolean })
+    | undefined
+) => {
+  let expiry = 5 * 60; // 5 min default
+  if (typeof options === "number") {
+    expiry = options;
+    options = undefined;
+  } else if (typeof options === "object") {
+    expiry = options.expireInSeconds ?? expiry;
   }
-  // Use the URL as the cache key to sessionStorage
-  let cacheKey = url
-  let cached = localStorage.getItem(cacheKey)
-  let whenCached = localStorage.getItem(cacheKey + ':ts')
-  if (cached !== null && whenCached !== null && !options?.forceRefresh) {
-    // it was in sessionStorage! Yay!
-    // Even though 'whenCached' is a string, this operation
-    // works because the minus sign converts the
-    // string to an integer and it will work.
-    let age = (Date.now() - parseInt(whenCached)) / 1000
+
+  let cacheKey = url;
+  let cached = (await chrome.storage.local.get(cacheKey))[cacheKey];
+  let whenCached = (await chrome.storage.local.get(cacheKey + ":ts"))[cacheKey + ":ts"];
+  
+  if (cached && whenCached !== null && !options?.forceRefresh) {
+    let age = (Date.now() - parseInt(whenCached)) / 1000;
     if (age < expiry) {
-      let response = new Response(new Blob([cached]))
-      return Promise.resolve(response)
+      let response = new Response(new Blob([cached]));
+      return Promise.resolve(response);
     } else {
-      // We need to clean up this old key
-      localStorage.removeItem(cacheKey)
-      localStorage.removeItem(cacheKey + ':ts')
+      chrome.storage.local.remove(cacheKey);
+      chrome.storage.local.remove(cacheKey + ":ts");
     }
   }
 
-  return fetch(url, options).then(response => {
-    // let's only store in cache if the content-type is
-    // JSON or something non-binary
+  return fetch(url, options).then((response) => {
     if (response.status === 200) {
-      let ct = response.headers.get('Content-Type')
-      if (ct && (ct.match(/application\/json/i) || ct.match(/text\//i))) {
-        // There is a .json() instead of .text() but
-        // we're going to store it in sessionStorage as
-        // string anyway.
-        // If we don't clone the response, it will be
-        // consumed by the time it's returned. This
-        // way we're being un-intrusive.
-        response.clone().text().then(content => {
-          localStorage.setItem(cacheKey, content)
-          localStorage.setItem(cacheKey+':ts', `${Date.now()}`)
-        })
+      let ct = response.headers.get("Content-Type");
+      if (ct && ct.match(/(application\/json|text\/.*)/i)) {
+        response
+          .clone()
+          .text()
+          .then((content) => {
+            chrome.storage.local.set({ [cacheKey]: content });
+            chrome.storage.local.set({ [cacheKey + ":ts"]: Date.now() });
+          });
       }
     }
-    return response
-  })
-}
+    return response;
+  });
+};

--- a/src/utils/fetchOpenSaucedApiData.ts
+++ b/src/utils/fetchOpenSaucedApiData.ts
@@ -27,7 +27,7 @@ export const checkTokenValidity = async (token: string) => {
 };
 
 export const getUserData = async (userName: string, forceRefresh: boolean = false) => {
-  return cachedFetch(`https://api.opensauced.pizza/v1/users/${userName}`, {
+  return cachedFetch(`${OPEN_SAUCED_USERS_ENDPOINT}/${userName}`, {
     expireInSeconds: 2 * 60 * 60, // 2 hours
     forceRefresh,
     headers: {
@@ -46,7 +46,7 @@ export const getUserData = async (userName: string, forceRefresh: boolean = fals
 }
 
 export const getUserPRData = async (userName: string, forceRefresh: boolean = false) => {
-  return cachedFetch(`https://api.opensauced.pizza/v1/users/${userName}/prs`, {
+  return cachedFetch(`${OPEN_SAUCED_USERS_ENDPOINT}/${userName}/prs`, {
     expireInSeconds: 2 * 60 * 60, // 2 hours
     forceRefresh,
     headers: {

--- a/src/utils/fetchOpenSaucedApiData.ts
+++ b/src/utils/fetchOpenSaucedApiData.ts
@@ -40,7 +40,6 @@ export const getUserData = async (userName: string, forceRefresh: boolean = fals
     return resp.json()
   })
     .then((json) => {
-      // console.log(json)
       return json
     })
 }
@@ -59,7 +58,6 @@ export const getUserPRData = async (userName: string, forceRefresh: boolean = fa
     return resp.json()
   })
     .then((json) => {
-      // console.log(json)
       return json
     })
 }

--- a/src/utils/fetchOpenSaucedApiData.ts
+++ b/src/utils/fetchOpenSaucedApiData.ts
@@ -1,3 +1,5 @@
+import { cachedFetch } from "./cache";
+
 export const getOpenSaucedUser = async (username: string) => {
   try {
     const response = await fetch(
@@ -23,3 +25,41 @@ export const checkTokenValidity = async (token: string) => {
   });
   return response.status === 200;
 };
+
+export const getUserData = async (userName: string, forceRefresh: boolean = false) => {
+  return cachedFetch(`https://api.opensauced.pizza/v1/users/${userName}`, {
+    expireInSeconds: 2 * 60 * 60, // 2 hours
+    forceRefresh,
+    headers: {
+      Accept: 'application/json',
+    },
+  }).then((resp) => {
+    if (!resp.ok) {
+      console.log('error getting user info')
+    }
+    return resp.json()
+  })
+    .then((json) => {
+      // console.log(json)
+      return json
+    })
+}
+
+export const getUserPRData = async (userName: string, forceRefresh: boolean = false) => {
+  return cachedFetch(`https://api.opensauced.pizza/v1/users/${userName}/prs`, {
+    expireInSeconds: 2 * 60 * 60, // 2 hours
+    forceRefresh,
+    headers: {
+      Accept: 'application/json',
+    },
+  }).then((resp) => {
+    if (!resp.ok) {
+      console.log('error getting user PR info')
+    }
+    return resp.json()
+  })
+    .then((json) => {
+      // console.log(json)
+      return json
+    })
+}

--- a/src/utils/fetchOpenSaucedApiData.ts
+++ b/src/utils/fetchOpenSaucedApiData.ts
@@ -9,6 +9,10 @@ export const getOpenSaucedUser = async (username: string) => {
   }
 };
 
+export const isOpenSaucedUser = async (username: string) => {
+  return await getOpenSaucedUser(username) != false;
+}
+
 export const checkTokenValidity = async (token: string) => {
   const url = "https://api.opensauced.pizza/v1/auth/session";
   const response = await fetch(url, {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,3 +1,5 @@
+const plugin = require("tailwindcss/plugin");
+
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
@@ -14,6 +16,44 @@ module.exports = {
       }
     },
   },
-  plugins: [],
+  plugins: [
+    // plugin for centering dividers
+    // usage: <div class=" divide-white divide-y divider-y-center-2"></div>
+    plugin(function({ matchUtilities, theme }) {
+      matchUtilities(
+        {
+          'divider-x-center': (value) => {
+            return {
+              "& > :not([hidden]):first-child": {
+                paddingLeft: 0,
+              },
+              "& > :not([hidden])": {
+                paddingLeft: value,
+                paddingRight: value,
+              },
+              "& > :not([hidden]):last-child": {
+                paddingRight: 0,
+              },
+            };
+          },
+          'divider-y-center': (value) => {
+            return {
+              "& > :not([hidden]):first-child": {
+                paddingTop: 0,
+              },
+              "& > :not([hidden])": {
+                paddingTop: value,
+                paddingBottom: value,
+              },
+              "& > :not([hidden]):last-child": {
+                paddingBottom: 0,
+              },
+            };
+          }
+        },
+        { values: theme('padding') }
+      )
+    })
+  ],
   important: true,
 };


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/open-sauced/blob/HEAD/CONTRIBUTING.md#create-a-pull-request.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/open-sauced/blob/HEAD/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [x] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description

This PR add 2 pages to the extension popup/dropdown.
As written in the commit descriptions, here are the changes I made along with those two pages.
- Add tailwind plugin to centering tailwind divider, it can be found at `tailwind.config.cjs`. More often than not, tailwind divider would not be centered between elements, we need to specify padding corrections. therefore, I search the internet and found that plugin to simplify the proccess.
- Moving token retrieval to custom hooks so it can be used anywhere.
- add custom hooks to check current tab is github profile url and opensauced user
-  add activeTab permission to `manifest.json` to check url of current tab from extension popup (_this related to previous bullet point_)
- refactor routing logic to use `context api`, so it can be used anywhere without prop drilling
- refactor `setRenderedPage` to accept props, because I need to pass username to profile page, this is another reason why I refactored the routing logic using `context api`, so I can pass props to `setRenderedPage`
- wrap `setRenderedPage` with `setCurrentPage` function to make it easy if we want to update route state without passing props
- add new util `cacheFetch` to be able cache data from api, reducing api calls.
- add `getUserData` on `fetchOpenSaucedApiData.ts` to fetch  more detailed user data
- add `getUserPRData` to fetch user PR data

Note:
I use inline styling 'flexWrap' in profile page because when I use tailwind `flex-wrap` class, it's interfering with github page (again). maybe we should use shadow DOM approach?
I know another workaround that doesn't involve Shadow DOM, we use 2 different tailwind.config.cjs, and add prefix to tailwind classes used in content-scripts (prefix can be set from `tailwind.config.cjs`), so it doesn't conflict with github page styles anymore.

Another note:
I don't use real data for `Avg PR velocity` and `Contributed Repos` in extension dropdown profile page , I just mimic the UI from Opensauced user dashboard, I don't know where the data came from or how to calculate the data.

Suggestion:
- Instead of manually writing routing logic, we could use [react-chrome-extension-router](https://www.npmjs.com/package/react-chrome-extension-router) , I use it in my submission and it's super simple to use.

## Related Tickets & Documents

Fixes #28 

## Mobile & Desktop Screenshots/Recordings

This add 2 pages to extension popup/dropdown: 
home page
![popup-homepage](https://user-images.githubusercontent.com/113872927/234480262-8149760b-9f85-4ff5-a5a9-f0f2ebb780b0.png)
@bdougie What do you think about this homepage? Is this the same as what you imagine?

and profile page
![popup-profile-page](https://user-images.githubusercontent.com/113872927/234480277-069b0436-844b-486d-a61a-d224e12da319.png)

If current tab is on github profile page, the profile is opensauced user, then new button/link to show profile will be added to tools section.
![extension-on-gh-profile](https://user-images.githubusercontent.com/113872927/234481206-7d0136cf-8e26-4c36-ba79-8e18972c1ce2.png)

and if the button is clicked, it will show the profile page with the profile data
![gh-profile-page](https://user-images.githubusercontent.com/113872927/234481294-90e61342-c5d0-48ab-9d42-c8ff36d945a5.png)

Screen record:

https://user-images.githubusercontent.com/113872927/234485105-38914486-4596-4031-aafe-ed69ccee61a0.mp4




## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

