### PR TITLE
feat: GitHub page update listener

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -25,5 +25,5 @@
     "128": "src/assets/os-icons/os-icon-128.png"
   },
   "host_permissions": ["<all_urls>"],
-  "permissions": ["storage","webRequest"]
+  "permissions": ["storage","webRequest", "activeTab", "tabs"]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -25,5 +25,5 @@
     "128": "src/assets/os-icons/os-icon-128.png"
   },
   "host_permissions": ["<all_urls>"],
-  "permissions": ["storage","webRequest", "activeTab", "tabs"]
+  "permissions": ["storage","webRequest", "activeTab", "tabs", "cookies"]
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,6 @@
 export const SUPABASE_LOCAL_STORAGE_KEY = "supabase.auth.token"
+export const SUPABASE_AUTH_DOMAIN = "ibcwmlhcimymasokhgvn.supabase.co"
+export const SUPABASE_COOKIE_NAME = "sb-access-token"
 export const SUPABASE_LOGIN_URL = "https://ibcwmlhcimymasokhgvn.supabase.co/auth/v1/authorize?provider=github&redirect_to=https://hot.opensauced.pizza/"
 export const SUPABASE_LOGOUT_URL = "https://ibcwmlhcimymasokhgvn.supabase.co/auth/v1/logout"
 export const OPEN_SAUCED_AUTH_TOKEN_KEY = "os-access-token"

--- a/src/content-scripts/profileScreen.ts
+++ b/src/content-scripts/profileScreen.ts
@@ -11,4 +11,11 @@ if (username != null) {
   else injectInviteToOpenSauced(username);
 }
 };
+
+chrome.runtime.onMessage.addListener((request) => {
+  if (request.message === "GITHUB_URL_CHANGED") {
+    processProfilePage();
+  }
+});
+
 processProfilePage();

--- a/src/utils/urlMatchers.ts
+++ b/src/utils/urlMatchers.ts
@@ -1,5 +1,5 @@
 export const getGithubUsername = (url: string) => {
-  const match = url.match(/github\.com\/([^/]+)/);
+  const match = url.match(/github\.com\/([\w.-]+)/);
   return match && match[1];
 };
 

--- a/src/worker/background.ts
+++ b/src/worker/background.ts
@@ -17,9 +17,7 @@ chrome.tabs.onUpdated.addListener(function (tabId, changeInfo) {
 
 chrome.cookies.onChanged.addListener(async (changeInfo) => {
   try {
-  console.log("cookie changed")
   if (changeInfo.cookie.name != SUPABASE_COOKIE_NAME || changeInfo.cookie.domain != SUPABASE_AUTH_DOMAIN) return;
-  console.log("ITS OUR COOKIE!")
   if (changeInfo.removed) return chrome.storage.sync.remove(OPEN_SAUCED_AUTH_TOKEN_KEY);
   const isValidToken = await checkTokenValidity(changeInfo.cookie.value)
   if (!isValidToken) return chrome.storage.sync.remove(OPEN_SAUCED_AUTH_TOKEN_KEY);

--- a/src/worker/background.ts
+++ b/src/worker/background.ts
@@ -1,8 +1,14 @@
-import  { SUPABASE_LOGOUT_URL, OPEN_SAUCED_AUTH_TOKEN_KEY } from "../constants";
+import { SUPABASE_LOGOUT_URL, OPEN_SAUCED_AUTH_TOKEN_KEY } from "../constants";
 
 chrome.webRequest.onCompleted.addListener(
-    (details) => {
-      chrome.storage.sync.remove(OPEN_SAUCED_AUTH_TOKEN_KEY);
-    },
-    { urls: [SUPABASE_LOGOUT_URL] }
-  );
+  (details) => {
+    chrome.storage.sync.remove(OPEN_SAUCED_AUTH_TOKEN_KEY);
+  },
+  { urls: [SUPABASE_LOGOUT_URL] }
+);
+
+chrome.tabs.onUpdated.addListener(function (tabId, changeInfo) {
+  if (changeInfo.url?.includes("github.com")) {
+    chrome.tabs.sendMessage(tabId, { message: "GITHUB_URL_CHANGED" });
+  }
+});


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description
This PR updates the service worker with a `tabs.onUpdated` listener which checks for URL changes at `github.com` and notifies the content-script, resolving an issue with the profile page buttons mentioned in #35. 4aa584c7992c4c21d89c4ca98c6283d13cc905a5.

Additionally, 
* The regex used in [`getGithubUsername()`](https://github.com/open-sauced/browser-extensions/blob/6751fa55d65d5ab4b96b0d1d1fa3624780087e0f/src/utils/urlMatchers.ts#L1) has been updated to ensure that it only matches the username without any appended query parameters. 6751fa55d65d5ab4b96b0d1d1fa3624780087e0f.
* Adds a handler to the background worker to deal with any changes to the Supabase auth cookie. d4aa979d343ebab0c4c2ebc54a761ea5b8304f2e.

## Related Tickets & Documents
Resolves #35.

## Mobile & Desktop Screenshots/Recordings
Before:
![demo](https://user-images.githubusercontent.com/46051506/234628617-ad7d81ea-9ebf-46a3-8520-75b507abad22.gif)

After 4aa584c7992c4c21d89c4ca98c6283d13cc905a5:
![demo-2](https://user-images.githubusercontent.com/46051506/234628659-6bfb74fd-1243-43a3-b351-a3d312eec9b3.gif)


## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed

