### PR TITLE
fix: Duplicate buttons on GH profile page

### DIFF
--- a/src/content-scripts/profileScreen.ts
+++ b/src/content-scripts/profileScreen.ts
@@ -2,15 +2,16 @@ import { getGithubUsername } from "../utils/urlMatchers";
 import { isOpenSaucedUser } from "../utils/fetchOpenSaucedApiData";
 import injectViewOnOpenSauced from "../utils/dom-utils/viewOnOpenSauced";
 import injectInviteToOpenSauced from "../utils/dom-utils/inviteToOpenSauced";
-import { getGHColorScheme } from "../utils/colorPreference";
+import { prefersDarkMode } from "../utils/colorPreference";
 
 const processProfilePage = async () => {
   const username = getGithubUsername(window.location.href);
   if (username != null) {
-    const colorScheme = getGHColorScheme(document.cookie);
+    const darkMode = prefersDarkMode(document.cookie);
+    if (darkMode) document.documentElement.classList.add("dark");
     const user = await isOpenSaucedUser(username);
-    if (user) injectViewOnOpenSauced(username, colorScheme);
-    else injectInviteToOpenSauced(username, colorScheme);
+    if (user) injectViewOnOpenSauced(username);
+    else injectInviteToOpenSauced(username);
   }
 };
 

--- a/src/utils/colorPreference.ts
+++ b/src/utils/colorPreference.ts
@@ -1,13 +1,10 @@
-export type ColorScheme = "auto" | "light" | "dark";
+type ColorScheme = "auto" | "light" | "dark";
 
-export const getGHColorScheme = (cookieString: string) => {
+export const prefersDarkMode = (cookieString: string): boolean => {
   const regex = /(?<=\bcolor_mode=)[^;]+/g;
   const match = regex.exec(cookieString);
   const cookie = match && JSON.parse(decodeURIComponent(match[0]));
-  return (cookie.color_mode as ColorScheme) || "auto";
-};
-
-export const prefersDarkMode = (colorScheme: ColorScheme): boolean => {
+  const colorScheme: ColorScheme = cookie.color_mode ?? "auto";
   if (colorScheme === "auto") {
     return window.matchMedia("(prefers-color-scheme: dark)").matches;
   }

--- a/src/utils/dom-utils/inviteToOpenSauced.ts
+++ b/src/utils/dom-utils/inviteToOpenSauced.ts
@@ -2,12 +2,8 @@ import { GITHUB_PROFILE_MENU_SELECTOR } from "../../constants";
 import { InviteToOpenSaucedButton } from "../../content-scripts/components/InviteToOpenSauced/InviteToOpenSaucedButton";
 import { InviteToOpenSaucedModal } from "../../content-scripts/components/InviteToOpenSauced/InviteToOpenSaucedModal";
 import { getTwitterUsername, getLinkedInUsername } from "../urlMatchers";
-import { ColorScheme, prefersDarkMode } from "../colorPreference";
 
-const injectOpenSaucedInviteButton = (
-  username: string,
-  colorScheme: ColorScheme
-) => {
+const injectOpenSaucedInviteButton = (username: string) => {
   const emailAddress: string | undefined = (
     document.querySelector(`a[href^="mailto:"]`) as HTMLAnchorElement
   )?.href.substr(7);
@@ -32,11 +28,9 @@ const injectOpenSaucedInviteButton = (
     inviteToOpenSaucedButton
   );
 
-  const darkMode = prefersDarkMode(colorScheme);
   const userBio = document.querySelector(GITHUB_PROFILE_MENU_SELECTOR);
   if (!userBio || !userBio.parentNode) return;
-  if (darkMode) userBio.parentElement?.classList.add("dark");
-  if(userBio.lastChild?.isEqualNode(inviteToOpenSaucedButton)) return;
+  if (userBio.lastChild?.isEqualNode(inviteToOpenSaucedButton)) return;
   userBio.append(inviteToOpenSaucedButton);
   document.body.appendChild(inviteToOpenSaucedModal);
 };

--- a/src/utils/dom-utils/inviteToOpenSauced.ts
+++ b/src/utils/dom-utils/inviteToOpenSauced.ts
@@ -36,7 +36,8 @@ const injectOpenSaucedInviteButton = (
   const userBio = document.querySelector(GITHUB_PROFILE_MENU_SELECTOR);
   if (!userBio || !userBio.parentNode) return;
   if (darkMode) userBio.parentElement?.classList.add("dark");
-  userBio.parentNode.replaceChild(inviteToOpenSaucedButton, userBio);
+  if(userBio.lastChild?.isEqualNode(inviteToOpenSaucedButton)) return;
+  userBio.append(inviteToOpenSaucedButton);
   document.body.appendChild(inviteToOpenSaucedModal);
 };
 

--- a/src/utils/dom-utils/viewOnOpenSauced.ts
+++ b/src/utils/dom-utils/viewOnOpenSauced.ts
@@ -17,7 +17,8 @@ const injectViewOnOpenSaucedButton = (
   );
   if (!userBio || !userBio.parentNode) return;
   if (darkMode) userBio.parentElement?.classList.add("dark");
-  userBio.parentNode.replaceChild(viewOnOpenSaucedButton, userBio);
+  if(userBio.lastChild?.isEqualNode(viewOnOpenSaucedButton)) return;
+  userBio.append(viewOnOpenSaucedButton);
 };
 
 export default injectViewOnOpenSaucedButton;

--- a/src/utils/dom-utils/viewOnOpenSauced.ts
+++ b/src/utils/dom-utils/viewOnOpenSauced.ts
@@ -3,21 +3,15 @@ import {
   GITHUB_PROFILE_EDIT_MENU_SELECTOR,
 } from "../../constants";
 import { ViewOnOpenSaucedButton } from "../../content-scripts/components/ViewOnOpenSaucedButton/ViewOnOpenSaucedButton";
-import { ColorScheme, prefersDarkMode } from "../colorPreference";
 
-const injectViewOnOpenSaucedButton = (
-  username: string,
-  colorScheme: ColorScheme
-) => {
+const injectViewOnOpenSaucedButton = (username: string) => {
   const viewOnOpenSaucedButton = ViewOnOpenSaucedButton(username);
 
-  const darkMode = prefersDarkMode(colorScheme);
   const userBio = document.querySelector(
     `${GITHUB_PROFILE_MENU_SELECTOR}, ${GITHUB_PROFILE_EDIT_MENU_SELECTOR}`
   );
   if (!userBio || !userBio.parentNode) return;
-  if (darkMode) userBio.parentElement?.classList.add("dark");
-  if(userBio.lastChild?.isEqualNode(viewOnOpenSaucedButton)) return;
+  if (userBio.lastChild?.isEqualNode(viewOnOpenSaucedButton)) return;
   userBio.append(viewOnOpenSaucedButton);
 };
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [x] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description
This PR fixes the bug mentioned in #46 by adding a check for a pre-existing button before adding a new button into view. 03ef88cd5c00fe61a67ee33795cea4a5261855b2.

Additionally, this PR refactors the current GitHub color preference implementation to set the "dark" class globally for github.com if a dark theme is opted by the user in GH's appearance settings. This will be beneficial as it enables any new elements added to github.com to utilize the `dark:` variant for styling, ensuring consistency with the user's preferences. d0a709cf7f8c3e6361cf1d9547e1d7df97405585.

## Related Tickets & Documents
Resolves #46.

## Mobile & Desktop Screenshots/Recordings
#### Before:
> When switching from the overview to the repositories tab, a duplicate "View on OpenSauced" Button gets added to the webpage.

![image](https://user-images.githubusercontent.com/46051506/235157107-54724b49-eb23-4552-aba3-a4dc48802750.png)

#### After the patch:
![after](https://user-images.githubusercontent.com/46051506/235157191-f5bd7b44-a7c5-4d03-9cb7-7f6967d58e38.gif)

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed