### PR TITLE
fix: set-output deprecation warning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,10 @@ jobs:
       - name: "☁️ compute environment variables"
         id: env
         run: |
-          echo "::set-output name=DEPLOY_ENVIRONMENT::$([[ ${{ github.ref_name }} == 'main' ]] && echo 'production' || echo ${{ github.ref_name }})"
-          echo "::set-output name=DEPLOY_SUBDOMAIN::$([[ ${{ github.ref_name }} == 'main' ]] && echo '' || echo '${{ github.ref_name }}.')"
+          DEPLOY_ENVIRONMENT=$([[ ${{ github.ref_name }} == 'main' ]] && echo 'production' || echo ${{ github.ref_name }})
+          DEPLOY_SUBDOMAIN=$([[ ${{ github.ref_name }} == 'main' ]] && echo '' || echo "${{ github.ref_name }}.")
+          echo "DEPLOY_ENVIRONMENT=$DEPLOY_ENVIRONMENT" >> $GITHUB_ENV
+          echo "DEPLOY_SUBDOMAIN=$DEPLOY_SUBDOMAIN" >> $GITHUB_ENV
   build:
     name: Build application
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [x] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description
This PR fixes the `set-output` deprecation warning during the `setup` job of the release workflow by updating the run script. A test run of the updated workflow without the warnings can be found here, https://github.com/Anush008/browser-extensions/actions/runs/4839263469.

## Related Tickets & Documents
Resolves #41.

## Mobile & Desktop Screenshots/Recordings
Not applicable.


## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed