### PR TITLE
feat: manifest-bump-ci

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,41 @@ jobs:
         uses: open-sauced/release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  
+  bump-manifest:
+    name: Bump Manifest
+    runs-on: ubuntu-latest
+    needs:
+      - release
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
 
+    - name: Setup Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: '16.x'
+        
+    - name: Bump manifest.json version
+      run: |
+        git pull
+        npm i -g json
+        json -I -f manifest.json -e "this.version=\"$(json -f package.json version)\""
+        
+    - name: Commit and push manifest version bump
+      run: |
+        git config user.name "OpenSauced Manifest Bump"
+        git config user.email "hello@opensauced.pizza"
+        git add manifest.json
+        staged_changes=$(git diff --cached)
+        if [ -n "$staged_changes" ]; then
+          last_author=$(git log -1 --pretty=format:'%an <%ae>' | xargs)
+          git commit --author="$last_author" -m "Bump manifest version to $(json -f package.json version)"
+          git push
+        else
+          echo "No version bump to commit"
+        fi
+        
   cleanup:
     name: Cleanup actions
     needs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,7 @@ jobs:
         staged_changes=$(git diff --cached)
         if [ -n "$staged_changes" ]; then
           last_author=$(git log -1 --pretty=format:'%an <%ae>' | xargs)
-          git commit --author="$last_author" -m "Bump manifest version to $(json -f package.json version)"
+          git commit --author="$last_author" -m "Bump manifest version to $(json -f package.json version) [skip ci]"
           git push
         else
           echo "No version bump to commit"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [x] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description
This PR adds a `manifest.json` version bump job to [.github/workflows/release.yml](https://github.com/open-sauced/browser-extensions/blob/508acea546a0843dd7c5cf4b209cc9d91606a34b/.github/workflows/release.yml) CI.
After the sematic-release job, the bumped release version is retrieved from `package.json` and automatically set in `manifest.json` with the author of the commit being set to the original author of the release.

#### Note: 
https://github.com/open-sauced/browser-extensions/blob/508acea546a0843dd7c5cf4b209cc9d91606a34b/.github/workflows/release.yml#L108

Piping the author info to `xargs` ensures removal of any whitespace or leading characters. This is optional and can be removed.

Test runs of this updated workflow can be found here. https://github.com/Anush008/browser-extensions/actions.

## Related Tickets & Documents
Resolves #53.

## Mobile & Desktop Screenshots/Recordings
Not applicable.


## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed