### PR TITLE
fix: unrecognized-manifest-key error

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import { crx } from "@crxjs/vite-plugin";
-import * as manifest from "./manifest.json";
+import manifest from "./manifest.json" assert { type: "json" };
 
 // https://vitejs.dev/config/
 export default defineConfig({


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description
This PR fixes the `⚠️ Unrecognized manifest key 'default'` error that arises after the installation of the extension by replacing the namespace import of the `manifest.json` file, https://github.com/open-sauced/browser-extensions/blob/a447551d46ea35dde6b674853ab55094728014c2/vite.config.ts#L4 with a default import. https://github.com/open-sauced/browser-extensions/blob/587293a85c69514cc48fc2122728cda7e63918d9/vite.config.ts#L4

## Related Tickets & Documents


## Mobile & Desktop Screenshots/Recordings
![Screenshot 2023-04-30 205937](https://user-images.githubusercontent.com/46051506/235362296-55e02c22-fca0-42e0-bbb0-f22fe9d94074.png)


## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [x] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed
